### PR TITLE
Feature/add how to play button

### DIFF
--- a/WhatThePhrase.xcodeproj/project.pbxproj
+++ b/WhatThePhrase.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		40B33F9E2A09C95A00E10CC2 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 40B33F9D2A09C95A00E10CC2 /* FirebaseCrashlytics */; };
 		40B33FA02A09CA5D00E10CC2 /* FirebaseDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B33F9F2A09CA5D00E10CC2 /* FirebaseDelegate.swift */; };
 		40E86A3A29EB9D4B0039AF43 /* GameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E86A3929EB9D4B0039AF43 /* GameView.swift */; };
+		40A46E0529EC562600081BFF /* InfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A46E0429EC562600081BFF /* InfoView.swift */; };
 		F51D6BD52DEFB024007C767C /* kids_wordlists.json in Resources */ = {isa = PBXBuildFile; fileRef = F51D6BD42DEFB024007C767C /* kids_wordlists.json */; };
 /* End PBXBuildFile section */
 
@@ -71,6 +72,7 @@
 		40B33F912A09C8A800E10CC2 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		40B33F9F2A09CA5D00E10CC2 /* FirebaseDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseDelegate.swift; sourceTree = "<group>"; };
 		40E86A3929EB9D4B0039AF43 /* GameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameView.swift; sourceTree = "<group>"; };
+		40A46E0429EC562600081BFF /* InfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoView.swift; sourceTree = "<group>"; };
 		F51D6BD42DEFB024007C767C /* kids_wordlists.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = kids_wordlists.json; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -134,6 +136,7 @@
 				400AD9DF29ED05EE0092B66D /* AudioPlayerController.swift */,
 				405B0C2429EB95AB0001F479 /* ContentView.swift */,
 				40E86A3929EB9D4B0039AF43 /* GameView.swift */,
+				40A46E0429EC562600081BFF /* InfoView.swift */,
 				405B0C3829EB98830001F479 /* RequestManager.swift */,
 				40A46DFC29EC4A2A00081BFF /* SettingsView.swift */,
 				405B0C2629EB95AC0001F479 /* Assets.xcassets */,
@@ -356,6 +359,7 @@
 				40653A8129F4BD1100CB96AB /* LaunchScreenHostingController.swift in Sources */,
 				400AD9E029ED05EE0092B66D /* AudioPlayerController.swift in Sources */,
 				405B0C2529EB95AB0001F479 /* ContentView.swift in Sources */,
+				40A46E0529EC562600081BFF /* InfoView.swift in Sources */,
 				40A46DFD29EC4A2A00081BFF /* SettingsView.swift in Sources */,
 				405B0C3929EB98830001F479 /* RequestManager.swift in Sources */,
 				40653A7C29F46B9900CB96AB /* WhatThePhrase.swift in Sources */,

--- a/WhatThePhrase.xcodeproj/project.pbxproj
+++ b/WhatThePhrase.xcodeproj/project.pbxproj
@@ -560,7 +560,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.roguedeveloper.WhatThePhrase;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -598,7 +598,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.roguedeveloper.WhatThePhrase;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/WhatThePhrase/ContentView.swift
+++ b/WhatThePhrase/ContentView.swift
@@ -9,6 +9,7 @@ struct CategorySelection: Identifiable {
 struct ContentView: View {
     @State private var selectedCategoryItem: CategorySelection? = nil
     @State private var showSettings: Bool = false
+    @State private var showInfo: Bool = false
     @AppStorage("playAsTeams") private var playAsTeams: Bool = true
     @AppStorage("timerDuration") private var timerDuration: Int = 60
     @AppStorage("isKidsMode") private var isKidsMode: Bool = false
@@ -70,21 +71,32 @@ struct ContentView: View {
                             timerDuration: $timerDuration, 
                             isKidsMode: $isKidsMode)
             }
+            .sheet(isPresented: $showInfo) {
+                InfoView()
+            }
             .navigationTitle("Select Category")
-            .navigationBarItems(trailing:
-                Button(action: {
-                    showSettings = true
-                }) {
-                    Image(systemName: "gearshape")
-                        .font(.title)
-                }
+            .navigationBarItems(
+                leading:
+                    Button(action: {
+                        showInfo = true
+                    }) {
+                        Image(systemName: "info.circle")
+                            .font(.title)
+                    },
+                trailing:
+                    Button(action: {
+                        showSettings = true
+                    }) {
+                        Image(systemName: "gearshape")
+                            .font(.title)
+                    }
             )
         }
         .onAppear {
             // Ensure wordlists are loaded when view appears
             RequestManager.shared.preloadWordlists()
         }
-        .onChange(of: isKidsMode) { newValue in
+        .onChange(of: isKidsMode) { oldValue, newValue in
             let manager = RequestManager.shared
             manager.isKidsMode = newValue
             manager.resetUsedWords()

--- a/WhatThePhrase/GameView.swift
+++ b/WhatThePhrase/GameView.swift
@@ -307,7 +307,7 @@ public struct GameView: View {
             timeRemaining = timerDuration
             // Don't load words here - wait for game to start
         }
-        .onChange(of: timerDuration) { newValue in
+        .onChange(of: timerDuration) { oldValue, newValue in
             timeRemaining = newValue
         }
         .onDisappear {

--- a/WhatThePhrase/InfoView.swift
+++ b/WhatThePhrase/InfoView.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+struct InfoView: View {
+    @Environment(\.dismiss) var dismiss
+    
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    Section(header: Text("How to Play")
+                        .font(.headline)
+                        .padding(.top)) {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("1. Select a category from the main screen")
+                            Text("2. Tap 'Start' to begin the game")
+                            Text("3. One person prompts others to guess the word shown")
+                            Text("4. When someone guesses correctly, tap 'Correct' or the team button")
+                            Text("5. Tap 'Pass' to skip a word and get a new one")
+                            Text("6. Accumulate points before time runs out!")
+                        }
+                        .font(.body)
+                    }
+                    
+                    Section(header: Text("Scoring")
+                        .font(.headline)) {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("• Each correct guess earns 1 point")
+                            Text("• Points are tracked throughout the game")
+                            Text("• When time runs out, the team (or player) with the most points wins")
+                        }
+                        .font(.body)
+                    }
+                    
+                    Section(header: Text("Game Modes")
+                        .font(.headline)) {
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("Play As Teams")
+                                .font(.subheadline)
+                                .fontWeight(.semibold)
+                            Text("When enabled, two teams compete against each other. Tap the red or green button when your team guesses correctly.")
+                                .font(.body)
+                                .padding(.bottom, 4)
+                            
+                            Text("Individual Mode")
+                                .font(.subheadline)
+                                .fontWeight(.semibold)
+                            Text("When teams are disabled, everyone plays together. Tap 'Correct' when anyone guesses the word.")
+                                .font(.body)
+                                .padding(.bottom, 4)
+                            
+                            Text("Kids Mode")
+                                .font(.subheadline)
+                                .fontWeight(.semibold)
+                            Text("Kids Mode uses age-appropriate word lists that are easier and more suitable for children. Enable this in Settings.")
+                                .font(.body)
+                        }
+                    }
+                    
+                    Section(header: Text("Timer")
+                        .font(.headline)) {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("• Set your preferred game duration in Settings")
+                            Text("• Default is 60 seconds")
+                            Text("• A sound plays when time runs out")
+                        }
+                        .font(.body)
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("How to Play")
+            .navigationBarItems(trailing:
+                Button("Done") {
+                    dismiss()
+                }
+            )
+        }
+    }
+}
+
+struct InfoView_Previews: PreviewProvider {
+    static var previews: some View {
+        InfoView()
+    }
+}

--- a/WhatThePhrase/RequestManager.swift
+++ b/WhatThePhrase/RequestManager.swift
@@ -1,11 +1,55 @@
 import Foundation
 import Combine
 
-class RequestManager: ObservableObject {
+final class UsedWordsStore: @unchecked Sendable {
+    private var usedWords: [String: Set<String>] = [:]
+    private let queue = DispatchQueue(label: "com.whatthephrase.usedwords", attributes: .concurrent)
+    
+    func getRandomWord(category: String, words: [String], continuation: CheckedContinuation<String, Error>) {
+        queue.async(flags: .barrier) {
+            // Filter out used words
+            let used = self.usedWords[category, default: []]
+            let unusedWords = words.filter { !used.contains($0) }
+            
+            print("   - \(unusedWords.count) unused words available")
+            
+            if !unusedWords.isEmpty {
+                let randomWord = unusedWords.randomElement()!
+                self.usedWords[category, default: []].insert(randomWord)
+                print("🎯 Selected word: '\(randomWord)' from unused words")
+                continuation.resume(returning: randomWord)
+            } else {
+                print("⚠️ No unused words left in category '\(category)' - resetting used words")
+                // Reset used words for this category and try again
+                self.usedWords[category] = []
+                if let randomWord = words.randomElement() {
+                    self.usedWords[category] = [randomWord]
+                    print("🔄 Reset used words and selected: '\(randomWord)'")
+                    continuation.resume(returning: randomWord)
+                } else {
+                    continuation.resume(throwing: NSError(domain: "com.whatthephrase", code: 3, userInfo: [NSLocalizedDescriptionKey: "Failed to select a word"]))
+                }
+            }
+        }
+    }
+    
+    func resetUsedWords() {
+        queue.async(flags: .barrier) {
+            self.usedWords.removeAll()
+        }
+    }
+    
+    func getUsedWordsState() -> [String: Set<String>] {
+        return queue.sync {
+            return usedWords
+        }
+    }
+}
+
+final class RequestManager: ObservableObject {
     static let shared = RequestManager()
     
-    private var usedWords: [String: Set<String>] = [:]
-    private let queue = DispatchQueue(label: "com.whatthephrase.requestmanager", attributes: .concurrent)
+    private let usedWordsStore = UsedWordsStore()
     @Published var isKidsMode: Bool = false
     
     private init() {}
@@ -103,59 +147,27 @@ class RequestManager: ObservableObject {
         
         // Debug: Print current used words state
         print("📝 Current used words state:")
-        queue.sync {
-            for (cat, words) in usedWords {
-                print("   - \(cat): \(words.count) words used")
-            }
+        let usedWordsState = usedWordsStore.getUsedWordsState()
+        for (cat, words) in usedWordsState {
+            print("   - \(cat): \(words.count) words used")
         }
         
         // First try to get a word from the specified category
-        guard let words = wordlists[category] as? [String], !words.isEmpty else {
+        guard let words = wordlists[category], !words.isEmpty else {
             print("❌ No words found in category '\(category)'")
             throw NSError(domain: "com.whatthephrase", code: 1, userInfo: [NSLocalizedDescriptionKey: "No words found in category \(category)"])
         }
         
         print("✅ Found \(words.count) words in category '\(category)'")
         
-        // Thread-safe access to usedWords
+        // Thread-safe access to usedWords via Sendable helper
         return try await withCheckedThrowingContinuation { continuation in
-            queue.async(flags: .barrier) { [weak self] in
-                guard let self = self else {
-                    continuation.resume(throwing: NSError(domain: "com.whatthephrase", code: 2, userInfo: [NSLocalizedDescriptionKey: "RequestManager deallocated"]))
-                    return
-                }
-                
-                // Filter out used words
-                let used = self.usedWords[category, default: []]
-                let unusedWords = words.filter { !used.contains($0) }
-                
-                print("   - \(unusedWords.count) unused words available")
-                
-                if !unusedWords.isEmpty {
-                    let randomWord = unusedWords.randomElement()!
-                    self.usedWords[category, default: []].insert(randomWord)
-                    print("🎯 Selected word: '\(randomWord)' from unused words")
-                    continuation.resume(returning: randomWord)
-                } else {
-                    print("⚠️ No unused words left in category '\(category)' - resetting used words")
-                    // Reset used words for this category and try again
-                    self.usedWords[category] = []
-                    if let randomWord = words.randomElement() {
-                        self.usedWords[category] = [randomWord]
-                        print("🔄 Reset used words and selected: '\(randomWord)'")
-                        continuation.resume(returning: randomWord)
-                    } else {
-                        continuation.resume(throwing: NSError(domain: "com.whatthephrase", code: 3, userInfo: [NSLocalizedDescriptionKey: "Failed to select a word"]))
-                    }
-                }
-            }
+            usedWordsStore.getRandomWord(category: category, words: words, continuation: continuation)
         }
     }
 
     func resetUsedWords() {
-        queue.async(flags: .barrier) { [weak self] in
-            self?.usedWords.removeAll()
-        }
+        usedWordsStore.resetUsedWords()
     }
     
     func setKidsMode(_ enabled: Bool) {

--- a/WhatThePhrase/SettingsView.swift
+++ b/WhatThePhrase/SettingsView.swift
@@ -19,7 +19,7 @@ struct SettingsView: View {
             Form {
                 Section(header: Text("Game Mode")) {
                     Toggle("Kids Mode", isOn: $isKidsMode)
-                        .onChange(of: isKidsMode) { newValue in
+                        .onChange(of: isKidsMode) { oldValue, newValue in
                             requestManager.isKidsMode = newValue
                             requestManager.resetUsedWords()
                         }

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,2 +1,3 @@
-- Added Kids Mode with age-appropriate word categories for younger players
+- New "How to Play" info screen - tap the info icon to learn the rules and game modes
+- Kids Mode with age-appropriate word categories for younger players
 - Bug fixes and performance improvements


### PR DESCRIPTION
Adds a how to play button, fixes older iOS syntax to be iOS 17+ compliant, moves used words into a helper instead of sending with self

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an in-app guide and modernizes state handling while improving word selection concurrency.
> 
> - Adds `InfoView` and an info-button in `ContentView` to present a "How to Play" screen
> - Refactors used-word tracking into `UsedWordsStore` (thread-safe) and updates `RequestManager.asyncGetRandomWord` to use it
> - Updates `.onChange` syntax to iOS 17 style in `ContentView`, `GameView`, and `SettingsView`
> - Bumps app marketing version to `1.2` and updates release notes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9feed52765d8ca0a8d739f5f3a39edc60638c3ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->